### PR TITLE
Remove reference waybar-hyprland

### DIFF
--- a/pages/Useful Utilities/Status-Bars.md
+++ b/pages/Useful Utilities/Status-Bars.md
@@ -6,20 +6,7 @@
 
 Waybar is a GTK status bar made specifically for wlroots compositors.
 
-To use it, it's recommended to use your distro's package by searching `waybar-hyprland`.
-
-## Compiling Manually
-
-To compile manually:
-
-Clone the source, cd into it, then do:
-
-```bash
-sed -i -e 's/zext_workspace_handle_v1_activate(workspace_handle_);/const std::string command = "hyprctl dispatch workspace " + name_;\n\tsystem(command.c_str());/g' src/modules/wlr/workspace_manager.cpp
-meson --prefix=/usr --buildtype=plain --auto-features=enabled --wrap-mode=nodownload build
-meson configure -Dexperimental=true build
-sudo ninja -C build install
-```
+To use it, it's recommended to use your distro's package by searching `waybar`.
 
 If you want to use the workspaces module, first, copy the configuration files from
 `/etc/xdg/waybar/` into `~/.config/waybar/`. Then, in `~/.config/waybar/config` replace


### PR DESCRIPTION
The latest release of waybar properly implements ext_workspace_unstable_v1 and doesn't require any patch to work with hyprland. I just removed the compiling section and renamed `waybar-hyprland` to just `waybar`